### PR TITLE
Use meson for Unix build as well so that .pc files are provided

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -51,7 +51,7 @@ jobs:
       source activate base
       echo "Configuring conda."
 
-      setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      setup_conda_rc ./ "./recipe" ./.ci_support/${CONFIG}.yaml
       export CI=azure
       source run_conda_forge_build_setup
       conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
@@ -62,23 +62,23 @@ jobs:
 
   - script: |
       source activate base
-      mangle_compiler ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      mangle_compiler ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Mangle compiler
 
   - script: |
       source activate base
-      make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      make_build_number ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Generate build number clobber file
 
   - script: |
       source activate base
-      conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+      conda build "./recipe" -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
     displayName: Build recipe
 
   - script: |
       source activate base
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
-      upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      upload_package ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -10,16 +10,16 @@ jobs:
   strategy:
     maxParallel: 4
     matrix:
-      win_c_compilervs2015python3.6.____cpython:
-        CONFIG: win_c_compilervs2015python3.6.____cpython
+      win_python3.6.____cpython:
+        CONFIG: win_python3.6.____cpython
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
-      win_c_compilervs2015python3.7.____cpython:
-        CONFIG: win_c_compilervs2015python3.7.____cpython
+      win_python3.7.____cpython:
+        CONFIG: win_python3.7.____cpython
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
-      win_c_compilervs2015python3.8.____cpython:
-        CONFIG: win_c_compilervs2015python3.8.____cpython
+      win_python3.8.____cpython:
+        CONFIG: win_python3.8.____cpython
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
   steps:
@@ -72,7 +72,7 @@ jobs:
     - script: set PYTHONUNBUFFERED=1
 
     # Configure the VM
-    - script: setup_conda_rc .\ .\recipe .\.ci_support\%CONFIG%.yaml
+    - script: setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
 
     # Configure the VM.
     - script: |
@@ -88,7 +88,7 @@ jobs:
 
     # Special cased version setting some more things!
     - script: |
-        conda.exe build recipe -m .ci_support\%CONFIG%.yaml
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe (vs2008)
       env:
         VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
@@ -96,7 +96,7 @@ jobs:
       condition: contains(variables['CONFIG'], 'vs2008')
 
     - script: |
-        conda.exe build recipe -m .ci_support\%CONFIG%.yaml
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1
@@ -104,7 +104,7 @@ jobs:
 
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
-        upload_package .\ .\recipe .ci_support\%CONFIG%.yaml
+        upload_package .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.ci_support/win_python3.6.____cpython.yaml
+++ b/.ci_support/win_python3.6.____cpython.yaml
@@ -13,7 +13,4 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_cpython
-zip_keys:
-- - c_compiler
-  - python
+- 3.6.* *_cpython

--- a/.ci_support/win_python3.7.____cpython.yaml
+++ b/.ci_support/win_python3.7.____cpython.yaml
@@ -13,7 +13,4 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.6.* *_cpython
-zip_keys:
-- - c_compiler
-  - python
+- 3.7.* *_cpython

--- a/.ci_support/win_python3.8.____cpython.yaml
+++ b/.ci_support/win_python3.8.____cpython.yaml
@@ -14,6 +14,3 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
-zip_keys:
-- - c_compiler
-  - python

--- a/README.md
+++ b/README.md
@@ -85,24 +85,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2015python3.6.____cpython</td>
+              <td>win_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=846&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pycairo-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015python3.6.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pycairo-feedstock?branchName=master&jobName=win&configuration=win_python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2015python3.7.____cpython</td>
+              <td>win_python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=846&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pycairo-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pycairo-feedstock?branchName=master&jobName=win&configuration=win_python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2015python3.8.____cpython</td>
+              <td>win_python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=846&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pycairo-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pycairo-feedstock?branchName=master&jobName=win&configuration=win_python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -29,9 +29,6 @@ if errorlevel 1 exit 1
 ninja -v -C builddir
 if errorlevel 1 exit 1
 
-ninja -C builddir test
-if errorlevel 1 exit 1
-
 ninja -C builddir install
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -29,6 +29,9 @@ if errorlevel 1 exit 1
 ninja -v -C builddir
 if errorlevel 1 exit 1
 
+ninja -C builddir test
+if errorlevel 1 exit 1
+
 ninja -C builddir install
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,4 +8,25 @@ if [ $(uname) = Darwin ] ; then
     export MACOSX_DEPLOYMENT_TARGET=10.9
 fi
 
-python setup.py install
+# We're using the meson build system as opposed to 'pip install .' because it provides
+# the pkg-config files for `pycairo`. These are used by downstream packages (notably
+# `pygobject`) that also use the meson build system in order to locate `pycairo`.
+# Without them, `pycairo` will not be found and might be built as an in-tree subproject
+# which is obviously undesirable.
+
+# meson options
+meson_config_args=(
+  --prefix="$PREFIX"
+  --libdir=lib
+  --wrap-mode=nofallback
+  --buildtype=release
+  --backend=ninja
+  -D python="$PYTHON"
+)
+
+# configure build using meson
+meson setup builddir "${meson_config_args[@]}"
+
+ninja -v -C builddir -j ${CPU_COUNT}
+ninja -C builddir test
+ninja -C builddir install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,3 +30,12 @@ meson setup builddir "${meson_config_args[@]}"
 ninja -v -C builddir -j ${CPU_COUNT}
 ninja -C builddir test
 ninja -C builddir install
+
+# meson installs to the wrong location for PyPy, so move the files manually
+PYTHON_IMPL=$($PYTHON -c "import platform; print(platform.python_implementation())")
+if [ "$PYTHON_IMPL" = "PyPy" ]; then
+    INSTALL_PLATLIB=$($PYTHON -c "import sysconfig; print(sysconfig.get_path('platlib'))")
+    cd $PREFIX/lib/pypy*/site-packages
+    mv *.egg-info $INSTALL_PLATLIB
+    mv cairo $INSTALL_PLATLIB
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ test:
 
 about:
   home: http://cairographics.org/pycairo/
-  license: LGPL 2.1, MPL 1.1
+  license: LGPL-2.1-only OR MPL-1.1
   license_file: COPYING
   summary: 'Python bindings for the Cairo graphics library.'
   dev_url: https://github.com/pygobject/pycairo/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,21 +11,22 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   detect_binary_files_with_prefix: true
   skip: true  # [py < 35]
 
 requirements:
   build:
-    - meson  # [win]
+    - meson
     - pkg-config
     - posix  # [win]
     - {{ compiler('c') }}
   host:
     - cairo
     - cython
-    - pip
+    - flake8  # for testing during the build
     - pthread-stubs
+    - pytest  # for testing during the build
     - python
     - xorg-libx11 1.6.*
     - xorg-xproto
@@ -38,6 +39,7 @@ test:
     - cairo
   commands:
     # verify the pkgconfig files get installed
+    - test -f $PREFIX/lib/pkgconfig/py3cairo.pc  # [unix]
     - if not exist %LIBRARY_LIB%\\pkgconfig\\py3cairo.pc exit 1  # [win]
 
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
As with the Windows build (#16), apparently missing `pkg-config` files are causing problems on the Unix side as well. It seems that `pygobject` has been failing to find `pycairo` and instead succeeding by building `pycairo` as an in-tree subproject, resulting in bits of `pycairo` (including a header, the py3cairo.pc file, and a Python egg file) being included in the most recent Linux/OSX builds.

This switches to using `meson` for the Unix build as well, since it provides the necessary `pkg-config` files. I also added `pytest` testing for parity with the `pygobject` build.